### PR TITLE
Add workflow for publishing to Crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+name: Publish to crates.io
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - run: cargo publish --token ${CRATES_TOKEN}
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "mediawiki"
 version = "0.0.1"
+description = "Rust crate to interface with the MediaWiki API, with special sauce for the Official Feed The Beast Wiki's extensions"
 authors = ["Peter Atashian <retep998@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"
+homepage = "https://github.com/FTB-Gamepedia/mediawiki-rs"
+repository = "https://github.com/FTB-Gamepedia/mediawiki-rs"
+readme = "README.md"
 
 [dependencies]
 cookie = "0.15"


### PR DESCRIPTION
This adds a GitHub Action that publishes this crate to Crates.io whenever a new Git tag is published. (Note that you also need to modify the `Cargo.toml` for the upload to behave properly.)

This also adds some metadata for better discovery on Crates.io once we publish our first version.

Closes #3