### PR TITLE
Add `format=original` query parameter to download URLs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ impl Mediawiki {
         let url = format!("{}{}format=original", lossy_url,
                           if lossy_url.contains('?') { '&' } else { '?' });
         let mut response = loop {
-            let mut request = self.client.request(Method::GET, url);
+            let mut request = self.client.request(Method::GET, &url);
             request = request.header(USER_AGENT, &*self.config.useragent);
             let response = request.send()?;
             if response.status() == StatusCode::OK {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,9 +160,11 @@ impl Mediawiki {
         if !image["missing"].is_null() {
             return Ok(None);
         }
-        let url = image["imageinfo"][0]["url"]
+        let lossy_url = image["imageinfo"][0]["url"]
             .as_str()
             .ok_or_else(|| Error::Json(image.clone()))?;
+        let url = format!("{}{}format=original", lossy_url,
+                          if lossy_url.contains('?') { '&' } else { '?' });
         let mut response = loop {
             let mut request = self.client.request(Method::GET, url);
             request = request.header(USER_AGENT, &*self.config.useragent);


### PR DESCRIPTION
This is needed because `webp` files may be downloaded otherwise.
Now, the original file is actually retrieved.